### PR TITLE
Fix reserveRemaining to take cancellations into account

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,8 +36,11 @@ class Piece {
 
   reserveRemaining () {
     if (!this.init()) return -1
-    if (this._reservations < this._chunks) {
-      const min = this._reservations
+    if (this._cancellations.length || this._reservations < this._chunks) {
+      let min = this._reservations
+      while (this._cancellations.length) {
+        min = Math.min(min, this._cancellations.pop())
+      }
       this._reservations = this._chunks
       return min
     }


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Without this patch, `reserveRemaining` ignores cancellations. If a piece is cancelled (e.g. because a peer disconnected), and then webtorrent tries to refetch that piece from a web seed using `reserveRemaining`, the full piece would never get fetched.

This meant that if a web seed was the only remaining peer the torrent would permanently stall. This fixes that issue. The only downside is that it may end up fetching a few extra chunks, but that's unavoidable when trying to reserve the rest of a piece at once (what `reserveRemaining` does) when that piece may have chunks missing throughout.

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**
